### PR TITLE
Hman 324

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,4 +26,4 @@ idam:
     url: ${IDAM_S2S_URL:http://localhost:4502}
 
 cronjob:
-  enabled: true
+  enabled: ${HEARING_NEXT_DAY_CRON_JOB:true}


### PR DESCRIPTION
     HMAN-324: Add Next Hearing Date Service to ccd-docker
        [HMAN-324] (https://tools.hmcts.net/jira/browse/HMAN-324).

