### PR TITLE
HMAN-493 Enable cleanup of helm release on success

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,5 +1,6 @@
 #!groovy
 import uk.gov.hmcts.contino.AppPipelineDsl
+import uk.gov.hmcts.contino.GithubAPI
 import uk.gov.hmcts.contino.GradleBuilder
 import uk.gov.hmcts.contino.HealthChecker
 
@@ -96,7 +97,10 @@ withPipeline(type, product, component) {
     env.DEFINITION_STORE_URL_BASE = "https://ccd-definition-store-ccd-next-hearing-date-updater-pr-${CHANGE_ID}.service.core-compute-preview.internal"
     env.TEST_STUB_SERVICE_BASE_URL = "http://ccd-next-hearing-date-updater-pr-${CHANGE_ID}-ccd-test-stubs-service" // NB : when def file is imported this will lead to data-store.preview -> test-stub.preview.
 
-    enableCleanupOfHelmReleaseOnSuccess()
+    def githubApi = new GithubAPI(this)
+    if (!githubApi.getLabelsbyPattern(env.BRANCH_NAME, "keep-helm")) {
+        enableCleanupOfHelmReleaseAlways()
+    }
   }
   onNonPR {
     env.ENV='aat'

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -94,6 +94,8 @@ withPipeline(type, product, component) {
     env.TEST_URL="https://ccd-data-store-api-ccd-next-hearing-date-updater-pr-${CHANGE_ID}.service.core-compute-preview.internal" // This is really not needed but here as a hack around TLS url
     env.CCD_DATA_STORE_API_BASE_URL = "https://ccd-data-store-api-ccd-next-hearing-date-updater-pr-${CHANGE_ID}.service.core-compute-preview.internal"
     env.DEFINITION_STORE_URL_BASE = "https://ccd-definition-store-ccd-next-hearing-date-updater-pr-${CHANGE_ID}.service.core-compute-preview.internal"
+
+    enableCleanupOfHelmReleaseOnSuccess()
   }
   onNonPR {
     env.ENV='aat'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
   id 'org.springframework.boot' version '2.7.5'
   id 'com.github.ben-manes.versions' version '0.42.0'
   id 'org.sonarqube' version '3.3'
-  id 'uk.gov.hmcts.java' version '0.12.34'
+  id 'uk.gov.hmcts.java' version '0.12.39'
   id 'com.github.hmcts.rse-cft-lib' version '0.19.496'
   id 'com.github.spacialcircumstances.gradle-cucumber-reporting' version '0.1.23'
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [HMAN-493](https://tools.hmcts.net/jira/browse/HMAN-493) _"Next Hearing Date Updater - for preview pipelines enable cleanup of helm release on success"_

### Change description ###

For preview pipelines, enable cleanup of helm release on success

#### Tested in: ####

NB: evidence also [attached to ticket](https://tools.hmcts.net/jira/browse/HMAN-493?focusedId=1513284#comment-1513284).

* [[Run 4]](https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fccd-next-hearing-date-updater/detail/PR-112/4/pipeline) without `keep-helm` label
* [[Run 5]](https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fccd-next-hearing-date-updater/detail/PR-112/5/pipeline) with `keep-helm` label

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
