### PR TITLE
HMAN-493 test updates to cnp-jenkins-library

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -95,6 +95,7 @@ withPipeline(type, product, component) {
     env.CCD_DATA_STORE_API_BASE_URL = "https://ccd-data-store-api-ccd-next-hearing-date-updater-pr-${CHANGE_ID}.service.core-compute-preview.internal"
     env.DEFINITION_STORE_URL_BASE = "https://ccd-definition-store-ccd-next-hearing-date-updater-pr-${CHANGE_ID}.service.core-compute-preview.internal"
 
+    enableFullFunctionalTest()
     enableCleanupOfHelmReleaseOnSuccess()
   }
   onNonPR {
@@ -136,32 +137,28 @@ withPipeline(type, product, component) {
     junit '**/test-results/test/*.xml'
   }
 
-  afterAlways('akschartsinstall') {
-
-     // check data-store instance is up
+  before('fullFunctionalTest:preview') {
+    // check data-store instance is up
     def healthChecker = new HealthChecker(this)
     healthChecker.check("$CCD_DATA_STORE_API_BASE_URL/health", 10, 40)
 
-    try {
-      // NB: override IDAM_API_URL late so its value does not corrupt config used in integration tests
-      env.IDAM_API_URL = env.IDAM_API_URL_BASE
+    // NB: override IDAM_API_URL late so its value does not corrupt config used in integration tests
+    env.IDAM_API_URL = env.IDAM_API_URL_BASE
 
-      // suppress SSL warnings as we are crossing boundary jenkins -> preview `feign.httpclient.disable-ssl-validation: true`
-      env.FEIGN_HTTPCLIENT_DISABLE_SSL_VALIDATION = true
+    // suppress SSL warnings as we are crossing boundary jenkins -> preview `feign.httpclient.disable-ssl-validation: true`
+    env.FEIGN_HTTPCLIENT_DISABLE_SSL_VALIDATION = true
+  }
 
-      builder.functionalTest()
-    } finally {
-
-      publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "build/reports/tests/functional",
-        reportFiles          : "overview-features.html,overview-failures.html,",
-        reportTitles         : "Features,Failures",
-        reportName           : "Next Hearing Date Updater Functional Test Report"
-      ]
-      junit '**/test-results/functional/*.xml'
-    }
+  afterAlways('fullFunctionalTest:preview') {
+    publishHTML target: [
+      allowMissing         : true,
+      alwaysLinkToLastBuild: true,
+      keepAll              : true,
+      reportDir            : "build/reports/tests/functional",
+      reportFiles          : "overview-features.html,overview-failures.html,",
+      reportTitles         : "Features,Failures",
+      reportName           : "Next Hearing Date Updater Functional Test Report"
+    ]
+    junit '**/test-results/functional/*.xml'
   }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -91,7 +91,6 @@ withPipeline(type, product, component) {
   onPR {
     enableSlackNotifications('#ccd-pr-builds')
     env.ENV='preview'
-    env.TEST_URL="https://ccd-data-store-api-ccd-next-hearing-date-updater-pr-${CHANGE_ID}.service.core-compute-preview.internal" // This is really not needed but here as a hack around TLS url
     env.CCD_DATA_STORE_API_BASE_URL = "https://ccd-data-store-api-ccd-next-hearing-date-updater-pr-${CHANGE_ID}.service.core-compute-preview.internal"
     env.DEFINITION_STORE_URL_BASE = "https://ccd-definition-store-ccd-next-hearing-date-updater-pr-${CHANGE_ID}.service.core-compute-preview.internal"
 
@@ -100,7 +99,6 @@ withPipeline(type, product, component) {
   }
   onNonPR {
     env.ENV='aat'
-    env.TEST_URL="http://ccd-data-store-api-aat.service.core-compute-aat.internal"
     env.CCD_DATA_STORE_API_BASE_URL = "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
     env.DEFINITION_STORE_URL_BASE = "http://ccd-definition-store-api-aat.service.core-compute-aat.internal"
   }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -94,6 +94,8 @@ withPipeline(type, product, component) {
     env.TEST_URL="https://ccd-data-store-api-ccd-next-hearing-date-updater-pr-${CHANGE_ID}.service.core-compute-preview.internal" // This is really not needed but here as a hack around TLS url
     env.CCD_DATA_STORE_API_BASE_URL = "https://ccd-data-store-api-ccd-next-hearing-date-updater-pr-${CHANGE_ID}.service.core-compute-preview.internal"
     env.DEFINITION_STORE_URL_BASE = "https://ccd-definition-store-ccd-next-hearing-date-updater-pr-${CHANGE_ID}.service.core-compute-preview.internal"
+
+    enableCleanupOfHelmReleaseOnSuccess()
   }
   onNonPR {
     env.ENV='aat'

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -15,7 +15,7 @@ properties([
   disableConcurrentBuilds()
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@HMAN-493_clearHelmRelease_nonServiceApp")
 
 def type = "java"
 def product = "ccd"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -78,7 +78,6 @@ withNightlyPipeline(type, product, component) {
 
   // apply standard `onNonPR` env variables for nightly
   env.ENV='aat'
-  env.TEST_URL="http://ccd-data-store-api-aat.service.core-compute-aat.internal"
   env.CCD_DATA_STORE_API_BASE_URL = "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
   env.DEFINITION_STORE_URL_BASE = "http://ccd-definition-store-api-aat.service.core-compute-aat.internal"
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -98,28 +98,20 @@ withNightlyPipeline(type, product, component) {
     echo "Loading the secrets"
     loadVaultSecrets(secrets)
 
+    // NB: override IDAM_API_URL late as per `Jenkinsfile_CNP` tests
+    env.IDAM_API_URL = env.IDAM_API_URL_BASE
+  }
 
-    // Execute functional tests
-    echo "Just waiting a while to ensure that the pod has run the job"
-    sh "sleep 30s"
-    echo "Verifying that functional test run correctly"
-    try {
-      // NB: override IDAM_API_URL late as per `Jenkinsfile_CNP` tests
-      env.IDAM_API_URL = env.IDAM_API_URL_BASE
-
-      builder.functionalTest()
-    } finally {
-
-      publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "build/reports/tests/functional",
-        reportFiles          : "overview-features.html,overview-failures.html,",
-        reportTitles         : "Features,Failures",
-        reportName           : "Next Hearing Date Updater Functional Test Report"
-      ]
-      junit '**/test-results/functional/*.xml'
-    }
+  afterAlways('fullFunctionalTest') {
+    publishHTML target: [
+      allowMissing         : true,
+      alwaysLinkToLastBuild: true,
+      keepAll              : true,
+      reportDir            : "build/reports/tests/functional",
+      reportFiles          : "overview-features.html,overview-failures.html,",
+      reportTitles         : "Features,Failures",
+      reportName           : "Next Hearing Date Updater Functional Test Report"
+    ]
+    junit '**/test-results/functional/*.xml'
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -335,7 +335,7 @@ dependencies {
   functionalTestImplementation group: 'io.vavr', name: 'vavr', version: '0.10.4'
   functionalTestImplementation group: 'io.rest-assured', name: 'rest-assured', version: '4.4.0'
 
-  functionalTestImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.6'
+  functionalTestImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.9-prerelease-HMAN-493'
   functionalTestImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.19.5'
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -336,7 +336,7 @@ dependencies {
   functionalTestImplementation group: 'io.rest-assured', name: 'rest-assured', version: '4.4.0'
 
   functionalTestImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.10'
-  functionalTestImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.19.10'
+  functionalTestImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.19.11'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -335,8 +335,8 @@ dependencies {
   functionalTestImplementation group: 'io.vavr', name: 'vavr', version: '0.10.4'
   functionalTestImplementation group: 'io.rest-assured', name: 'rest-assured', version: '4.4.0'
 
-  functionalTestImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.9-prerelease-HMAN-493'
-  functionalTestImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.19.5'
+  functionalTestImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '8.7.10'
+  functionalTestImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.19.10'
 
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [HMAN-493](https://tools.hmcts.net/jira/browse/HMAN-493) _"Next Hearing Date Updater - for preview pipelines enable cleanup of helm release on success"_

### Change description ###

Adjust jenkins pipeline config: `enableFullFunctionalTest(…)` and `enableCleanupOfHelmReleaseOnSuccess()` in PREVIEW.

#### Dependant on: #### 

* hmcts/cnp-jenkins-library#946
* hmcts/befta-fw#195

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
