### PR TITLE
HMAN-514 force Functional Tests to fail

### DIFF
--- a/src/functionalTest/resources/features/common/case-creation/CreateTestCase_NextHearingDate.td.json
+++ b/src/functionalTest/resources/features/common/case-creation/CreateTestCase_NextHearingDate.td.json
@@ -42,7 +42,7 @@
   "expectedResponse": {
     "body": {
       "jurisdiction": "BEFTA_MASTER",
-      "case_type": "FT_NextHearingDate",
+      "case_type": "FORCE-TEST-TO-FAIL",
       "data": {
         "nextHearingDetails": {
           "hearingID": 1234,


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [HMAN-514](https://tools.hmcts.net/jira/browse/HMAN-514) _"Next Hearing Date Updater - use jenkins step for Functional Tests"_

### Change description ###

Test jenkins pipeline changes from hmcts/cnp-jenkins-library#987:
* test when behaviour when **functional test stage fails**.

#### Dependant on: #### 

* hmcts/cnp-jenkins-library#987
* #135 **(base PR)**

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
