### PR TITLE
HMAN-514 force Functional Test Health Check to fail 

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -96,7 +96,8 @@ withPipeline(type, product, component) {
     env.DEFINITION_STORE_URL_BASE = "https://ccd-definition-store-ccd-next-hearing-date-updater-pr-${CHANGE_ID}.service.core-compute-preview.internal"
     env.TEST_STUB_SERVICE_BASE_URL = "http://ccd-next-hearing-date-updater-pr-${CHANGE_ID}-ccd-test-stubs-service" // NB : when def file is imported this will lead to data-store.preview -> test-stub.preview.
 
-    enableFullFunctionalTestNonServiceApp(env.CCD_DATA_STORE_API_BASE_URL)
+    // TODO: remove TEMPORARY OVERRIDE to test HealthCheck failure, reinstate: enableFullFunctionalTestNonServiceApp(env.CCD_DATA_STORE_API_BASE_URL)
+    enableFullFunctionalTestNonServiceApp("https://ccd-data-store-api-ccd-next-hearing-date-updater-pr-bad-number.service.core-compute-preview.internal")
 
     def githubApi = new GithubAPI(this)
     if (!githubApi.getLabelsbyPattern(env.BRANCH_NAME, "keep-helm")) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [HMAN-514](https://tools.hmcts.net/jira/browse/HMAN-514) _"Next Hearing Date Updater - use jenkins step for Functional Tests"_

### Change description ###

Test jenkins pipeline changes from hmcts/cnp-jenkins-library#987:
* test when behaviour when **functional test stage's Health Check fails**.

#### Dependant on: #### 

* hmcts/cnp-jenkins-library#987
* #135 **(base PR)**

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
