### PR TITLE
CCD-4398 Upgrade dependencies to resolve CVE-2023-24998

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,7 +303,8 @@ dependencies {
 
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.5'
   implementation group: 'commons-validator', name: 'commons-validator', version: '1.7'
-  implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+  implementation group: 'commons-io', name: 'commons-io', version: '2.11.0' 
+  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.1.2'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '2.1.1'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
-        CVE-2023-24998 refer https://tools.hmcts.net/jira/browse/CCD-4398</notes>
+        CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373</notes>
     <cve>CVE-2022-45688</cve>
-    <cve>CVE-2023-24998</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-4398


### Change description ###
Upgrade tomcat and commons-fileupload  to resolve CVE-2023-24998

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
