### PR TITLE
CCD-5159:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -344,6 +344,9 @@ dependencies {
 
   implementation group: 'org.yaml', name: 'snakeyaml', version: '2.0'
 
+  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.13'
+  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.13'
+
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLogging
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: reformLogging
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.2'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -5,7 +5,6 @@
         CVE-2023-35116 refer [Ticket]
         CVE-2023-5072  refer [Ticket]
         CVE-2023-34055 refer [Ticket]
-        CVE-2023-6378 refer [Ticket]
         CVE-2023-6481 refer [Ticket]
         CVE-2023-1370 refer [Ticket]
     </notes>
@@ -13,7 +12,6 @@
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-5072</cve>
     <cve>CVE-2023-34055</cve>
-    <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-6481</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
Fix CVE-2023-6378, removed CVE-6378 suppression as logback modules are not used in this project
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-5159


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
