### PR TITLE
CCD-5196:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -321,6 +321,12 @@ dependencyManagement {
 
 dependencies {
 
+  implementation('ch.qos.logback:logback-classic'){
+    version {
+      strictly '1.2.13'
+    }
+  }
+
   // Implementation dependencies
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter'
 
@@ -343,10 +349,15 @@ dependencies {
   implementation group: 'org.yaml', name: 'snakeyaml', version: '2.0'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLogging
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: reformLogging
+  implementation(group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: reformLogging) {
+    exclude group: 'ch.qos.logback', module: 'logback-classic'
+    exclude group: 'ch.qos.logback', module: 'logback-core'
+  }
 
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.2'
-  implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4'
+  implementation (group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4') {
+    exclude group: 'ch.qos.logback', module: 'logback-classic'
+  }
 
   implementation group: 'commons-validator', name: 'commons-validator', version: '1.7'
   implementation group: 'commons-io', name: 'commons-io', version: '2.14.0'

--- a/build.gradle
+++ b/build.gradle
@@ -326,6 +326,11 @@ dependencies {
       strictly '1.2.13'
     }
   }
+  implementation('ch.qos.logback:logback-core'){
+    version {
+      strictly '1.2.13'
+    }
+  }
 
   // Implementation dependencies
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -3,10 +3,8 @@
     <notes>Temporary Suppression
         CVE-2023-35116 refer [Ticket]
         CVE-2023-6378 refer [Ticket]
-        CVE-2023-6481 refer [Ticket]
     </notes>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-6378</cve>
-    <cve>CVE-2023-6481</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-5196


### Change description ###
Fix CVE-2023-6481, upgraded logback-classic and logback-core from 1.2.12 to 1.2.13


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
