### PR TITLE
CCD-7716: Updated java-logging to version 8.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -263,7 +263,7 @@ dependencyCheck {
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { 
+  maven {
     name = "AzureArtifacts"
     url = uri("https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1")
   }
@@ -310,7 +310,7 @@ ext {
   set('snakeyaml.version', '2.2')
   junit = '5.13.4'
   junitPlatform = '1.13.4'
-  reformLogging = '6.1.9'
+  reformLogging = '8.0.0'
   lombokVersion = '1.18.42'
   // test dependencies
   cucumberVersion = '7.28.2'
@@ -344,8 +344,8 @@ dependencies {
   // implementation group: 'com.example', name: 'example-lib', version: '1.0.0' //  parent dependency name
 
   // end::CVE Vulnerability dependency overrides                                                      // MAIN PARENT DEPENDEDNCY
-  
-  
+
+
   // Spring
   implementation group: 'org.springframework', name:'spring-webmvc'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter'
@@ -364,13 +364,8 @@ dependencies {
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.3'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLogging
-  implementation(group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.0.1') {
-    exclude group: 'ch.qos.logback', module: 'logback-classic'
-    exclude group: 'ch.qos.logback', module: 'logback-core'
-  }
 
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
-  implementation group: 'com.microsoft.azure', name: 'applicationinsights-spring-boot-starter', version: '2.6.4'
   implementation group: 'commons-validator', name: 'commons-validator', version: '1.10.1'
   implementation group: 'jakarta.servlet', name: 'jakarta.servlet-api', version: '6.1.0'
   implementation group: 'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: '1.15.0'

--- a/src/main/java/uk/gov/hmcts/reform/next/hearing/date/updater/ApplicationBootstrap.java
+++ b/src/main/java/uk/gov/hmcts/reform/next/hearing/date/updater/ApplicationBootstrap.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.next.hearing.date.updater;
 
-import com.microsoft.applicationinsights.TelemetryClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,21 +21,11 @@ public class ApplicationBootstrap implements ApplicationRunner {
     @Value("${next-hearing-date-updater.processing.enabled}")
     private boolean isProcessingEnabled;
 
-    @Value("${telemetry.wait.period:10000}")
-    private int waitPeriod;
-
     private final NextHearingDateUpdaterService nextHearingDateUpdaterService;
-    private final TelemetryClient client;
 
     @Autowired
     public ApplicationBootstrap(NextHearingDateUpdaterService nextHearingDateUpdaterService) {
         this.nextHearingDateUpdaterService = nextHearingDateUpdaterService;
-        this.client = new TelemetryClient();
-    }
-
-    public ApplicationBootstrap(NextHearingDateUpdaterService nextHearingDateUpdaterService, TelemetryClient client) {
-        this.nextHearingDateUpdaterService = nextHearingDateUpdaterService;
-        this.client = client;
     }
 
     @Override
@@ -48,15 +37,8 @@ public class ApplicationBootstrap implements ApplicationRunner {
                 log.info("Completed the Next-Hearing-Date-Updater job successfully triggered by cron job.");
             } catch (Exception exception) {
                 throw new ErrorDuringExecutionException("Error executing Next-Hearing-Date-Updater job.", exception);
-            } finally {
-                client.flush();
-                waitTelemetryGracefulPeriod();
             }
         }
-    }
-
-    private void waitTelemetryGracefulPeriod() throws InterruptedException {
-        Thread.sleep(waitPeriod);
     }
 
     public static void main(final String[] args) {

--- a/src/test/java/uk/gov/hmcts/reform/next/hearing/date/updater/ApplicationBootstrapTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/next/hearing/date/updater/ApplicationBootstrapTest.java
@@ -1,10 +1,8 @@
 package uk.gov.hmcts.reform.next.hearing.date.updater;
 
-import com.microsoft.applicationinsights.TelemetryClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.ApplicationArguments;
@@ -17,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.openMocks;
 import static uk.gov.hmcts.reform.next.hearing.date.updater.exceptions.ErrorDuringExecutionException.EXIT_FAILURE;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,42 +26,33 @@ class ApplicationBootstrapTest {
     @Mock
     private NextHearingDateUpdaterService nextHearingDateUpdaterService;
 
-    @Mock
-    private TelemetryClient client;
-
-    @InjectMocks
     private ApplicationBootstrap underTest;
 
     @BeforeEach
     void setUp() {
-        openMocks(this);
-        underTest = new ApplicationBootstrap(nextHearingDateUpdaterService, client);
+        underTest = new ApplicationBootstrap(nextHearingDateUpdaterService);
         ReflectionTestUtils.setField(underTest, "isProcessingEnabled", true);
     }
 
     @Test
     void testShouldRunExecutor() throws Exception {
         doNothing().when(nextHearingDateUpdaterService).execute();
-        doNothing().when(client).flush();
 
         underTest.run(applicationArguments);
 
         verify(nextHearingDateUpdaterService).execute();
-        verify(client).flush();
     }
 
     @Test
-    void testShouldRunExecutorWithException() throws Exception {
+    void testShouldRunExecutorWithException() {
         doThrow(new RuntimeException("test")).when(nextHearingDateUpdaterService).execute();
-        doNothing().when(client).flush();
 
         ErrorDuringExecutionException exception = assertThrows(
             ErrorDuringExecutionException.class, () -> underTest.run(applicationArguments)
         );
 
-        // NB: must still verify execute and `client.flush` have still been actioned
+        // NB: must still verify execute has been actioned
         verify(nextHearingDateUpdaterService).execute();
-        verify(client).flush();
         assertEquals(EXIT_FAILURE, exception.getExitCode(), "Expecting the failure exit code.");
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[CCD-7716](https://tools.hmcts.net/jira/browse/CCD-7716)


### Change description ###
Updated value of reformLogging property in build.gradle to 8.0.0. This property is used to specify the version of java-logging that is used.

Removed the java-logging logging-appinsights dependency. This was removed from java-logging in version 7.0.0 and no longer exists.

Removed all references to TelemetryClient from ApplicationBootstrap and ApplicationBootstrapTest.

Removed redundant InjectMocks annotation from ApplicationBootstrap object in ApplicationBootstrapTest.  Object was already being initialised in setUp() method.  Also removed redundant openMocks() call from setUp() method as mocks were already being initialised via ExtendWith annotation.

Removed redundant applicationinsights-spring-boot-starter dependency.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
